### PR TITLE
Rendering Additons 1 - WTW Renderer

### DIFF
--- a/src/main/java/code/elix_x/excore/utils/client/gui/elements/GuiElement.java
+++ b/src/main/java/code/elix_x/excore/utils/client/gui/elements/GuiElement.java
@@ -5,7 +5,7 @@ import org.lwjgl.opengl.GL11;
 import org.lwjgl.util.Rectangle;
 
 import code.elix_x.excomms.color.RGBA;
-import code.elix_x.excore.utils.client.render.ItemStackRenderer;
+import code.elix_x.excore.utils.client.render.item.ItemStackRenderer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.ScaledResolution;

--- a/src/main/java/code/elix_x/excore/utils/client/render/item/ItemStackRenderer.java
+++ b/src/main/java/code/elix_x/excore/utils/client/render/item/ItemStackRenderer.java
@@ -1,4 +1,4 @@
-package code.elix_x.excore.utils.client.render;
+package code.elix_x.excore.utils.client.render.item;
 
 import java.util.List;
 

--- a/src/main/java/code/elix_x/excore/utils/client/render/wtw/WTWRenderer.java
+++ b/src/main/java/code/elix_x/excore/utils/client/render/wtw/WTWRenderer.java
@@ -1,20 +1,41 @@
 package code.elix_x.excore.utils.client.render.wtw;
 
+import java.util.LinkedList;
+import java.util.Queue;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.lwjgl.opengl.GL11;
 
+import code.elix_x.excore.EXCore;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.Tessellator;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.relauncher.Side;
 
+@EventBusSubscriber(Side.CLIENT)
 public class WTWRenderer {
-	
-	public static void render(Tessellator borders, Tessellator world){
-		render(() -> borders.draw(), () -> world.draw());
+
+	private static Queue<Pair<Runnable, Runnable>> renderingQueue = new LinkedList<Pair<Runnable, Runnable>>();
+
+	@SubscribeEvent(priority= EventPriority.LOWEST)
+	static void renderLast(RenderWorldLastEvent event){
+		while(!renderingQueue.isEmpty()){
+			renderNow(renderingQueue.peek().getLeft(), renderingQueue.poll().getRight());
+		}
 	}
 
 	public static void render(Runnable borders, Runnable world){
+		renderingQueue.add(new ImmutablePair<Runnable, Runnable>(borders, world));
+	}
+
+	public static void renderNow(Runnable borders, Runnable world){
 		assert Minecraft.getMinecraft().getFramebuffer().isStencilEnabled() : "WTW Renderer can't work without stencils. Please enable them";
-				
+
 		GL11.glEnable(GL11.GL_STENCIL_TEST);
 		GlStateManager.colorMask(false, false, false, false);
 		GL11.glDepthMask(false);
@@ -31,5 +52,5 @@ public class WTWRenderer {
 		world.run();
 		GL11.glDisable(GL11.GL_STENCIL_TEST);
 	}
-	
+
 }

--- a/src/main/java/code/elix_x/excore/utils/client/render/wtw/WTWRenderer.java
+++ b/src/main/java/code/elix_x/excore/utils/client/render/wtw/WTWRenderer.java
@@ -7,7 +7,6 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.lwjgl.opengl.GL11;
 
-import code.elix_x.excore.EXCore;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
@@ -17,13 +16,16 @@ import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 
-@EventBusSubscriber(Side.CLIENT)
 public class WTWRenderer {
 
 	private static Queue<Pair<Runnable, Runnable>> renderingQueue = new LinkedList<Pair<Runnable, Runnable>>();
 
+	static {
+		MinecraftForge.EVENT_BUS.register(WTWRenderer.class);
+	}
+
 	@SubscribeEvent(priority= EventPriority.LOWEST)
-	static void renderLast(RenderWorldLastEvent event){
+	public static void renderLast(RenderWorldLastEvent event){
 		while(!renderingQueue.isEmpty()){
 			renderNow(renderingQueue.peek().getLeft(), renderingQueue.poll().getRight());
 		}
@@ -36,6 +38,7 @@ public class WTWRenderer {
 	public static void renderNow(Runnable borders, Runnable world){
 		assert Minecraft.getMinecraft().getFramebuffer().isStencilEnabled() : "WTW Renderer can't work without stencils. Please enable them";
 
+		GlStateManager.pushMatrix();
 		GL11.glEnable(GL11.GL_STENCIL_TEST);
 		GlStateManager.colorMask(false, false, false, false);
 		GL11.glDepthMask(false);
@@ -51,6 +54,7 @@ public class WTWRenderer {
 		GL11.glStencilFunc(GL11.GL_EQUAL, 1, 255);
 		world.run();
 		GL11.glDisable(GL11.GL_STENCIL_TEST);
+		GlStateManager.popMatrix();
 	}
 
 }

--- a/src/main/java/code/elix_x/excore/utils/client/render/wtw/WTWRenderer.java
+++ b/src/main/java/code/elix_x/excore/utils/client/render/wtw/WTWRenderer.java
@@ -1,7 +1,11 @@
 package code.elix_x.excore.utils.client.render.wtw;
 
+import java.util.Collections;
+import java.util.Deque;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
+import java.util.Stack;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -41,14 +45,14 @@ public class WTWRenderer {
 		GlStateManager.pushMatrix();
 		GL11.glEnable(GL11.GL_STENCIL_TEST);
 		GlStateManager.colorMask(false, false, false, false);
-		GL11.glDepthMask(false);
+		GlStateManager.depthMask(false);
 		GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 255);
 		GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
 		GL11.glStencilMask(255);
 		GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
 		borders.run();
-		GL11.glDepthMask(true);
-		GL11.glColorMask(true, true, true, true);
+		GlStateManager.depthMask(true);
+		GlStateManager.colorMask(true, true, true, true);
 		GL11.glStencilMask(0);
 
 		GL11.glStencilFunc(GL11.GL_EQUAL, 1, 255);

--- a/src/main/java/code/elix_x/excore/utils/client/render/wtw/WTWRenderer.java
+++ b/src/main/java/code/elix_x/excore/utils/client/render/wtw/WTWRenderer.java
@@ -1,0 +1,35 @@
+package code.elix_x.excore.utils.client.render.wtw;
+
+import org.lwjgl.opengl.GL11;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.Tessellator;
+
+public class WTWRenderer {
+	
+	public static void render(Tessellator borders, Tessellator world){
+		render(() -> borders.draw(), () -> world.draw());
+	}
+
+	public static void render(Runnable borders, Runnable world){
+		assert Minecraft.getMinecraft().getFramebuffer().isStencilEnabled() : "WTW Renderer can't work without stencils. Please enable them";
+				
+		GL11.glEnable(GL11.GL_STENCIL_TEST);
+		GlStateManager.colorMask(false, false, false, false);
+		GL11.glDepthMask(false);
+		GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 255);
+		GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
+		GL11.glStencilMask(255);
+		GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
+		borders.run();
+		GL11.glDepthMask(true);
+		GL11.glColorMask(true, true, true, true);
+		GL11.glStencilMask(0);
+
+		GL11.glStencilFunc(GL11.GL_EQUAL, 1, 255);
+		world.run();
+		GL11.glDisable(GL11.GL_STENCIL_TEST);
+	}
+	
+}

--- a/src/main/java/code/elix_x/excore/utils/client/render/wtw/WTWRenderer.java
+++ b/src/main/java/code/elix_x/excore/utils/client/render/wtw/WTWRenderer.java
@@ -49,7 +49,7 @@ public class WTWRenderer {
 		GL11.glStencilFunc(GL11.GL_ALWAYS, 1, 255);
 		GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
 		GL11.glStencilMask(255);
-		GL11.glClear(GL11.GL_STENCIL_BUFFER_BIT);
+		GlStateManager.clear(GL11.GL_STENCIL_BUFFER_BIT);
 		borders.run();
 		GlStateManager.depthMask(true);
 		GlStateManager.colorMask(true, true, true, true);

--- a/src/main/java/code/elix_x/excore/utils/client/render/wtw/WTWRenderer.java
+++ b/src/main/java/code/elix_x/excore/utils/client/render/wtw/WTWRenderer.java
@@ -1,11 +1,7 @@
 package code.elix_x.excore.utils.client.render.wtw;
 
-import java.util.Collections;
-import java.util.Deque;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Queue;
-import java.util.Stack;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -15,31 +11,59 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.relauncher.Side;
 
+/**
+ * <h1>World Through World Renderer</h1><br>
+ * Allows rendering of another world through the current world using stencils.<br>
+ * It only has the basic functionality. What is outer world, what is inner and how they are rendered is up to users of this class.<br><br>
+ * <b>I am irresponsible for any conflicts caused by incorrect usage of this class!</b>
+ * @author Elix_x
+ *
+ */
 public class WTWRenderer {
 
 	private static Queue<Pair<Runnable, Runnable>> renderingQueue = new LinkedList<Pair<Runnable, Runnable>>();
 
-	static {
+	static{
 		MinecraftForge.EVENT_BUS.register(WTWRenderer.class);
 	}
 
-	@SubscribeEvent(priority= EventPriority.LOWEST)
+	/**
+	 * <b>INTERNAL - DO NOT USE!</b>
+	 */
+	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void renderLast(RenderWorldLastEvent event){
 		while(!renderingQueue.isEmpty()){
 			renderNow(renderingQueue.peek().getLeft(), renderingQueue.poll().getRight());
 		}
 	}
 
-	public static void render(Runnable borders, Runnable world){
-		renderingQueue.add(new ImmutablePair<Runnable, Runnable>(borders, world));
+	/**
+	 * Renders the world through another world, or more specifically, enqueues it for rendering. Everything will be rendered in last possible moment to avoid conflicts.<br>
+	 * How everything is drawn is completely up to users of this class.
+	 * 
+	 * @param tear
+	 *            Draw a tear in the world through which the other world can be seen. Only position vertex parameters are used, others are ignored (depth and color buffers stay unmodified).
+	 * @param world
+	 *            Draw the actual world on the other side of the tear. You can draw everything, only parts visible through the tear will stay.
+	 */
+	public static void render(Runnable tear, Runnable world){
+		renderingQueue.add(new ImmutablePair<Runnable, Runnable>(tear, world));
 	}
 
-	public static void renderNow(Runnable borders, Runnable world){
+	/**
+	 * Renders the world through another world <b>right now</b>. <b>I am irresponsible for all conflicts caused by usage in wrong time.</b>
+	 * 
+	 * @param tear
+	 *            Draw a tear in the world through which the other world can be seen. Only position vertex parameters are used, others are ignored (depth and color buffers stay unmodified).
+	 * @param world
+	 *            Draw the actual world on the other side of the tear. You can draw everything, only parts visible through the tear will stay.
+	 * @throws Exceptions
+	 *             if stencils aren't enabled.
+	 */
+	public static void renderNow(Runnable tear, Runnable world){
 		assert Minecraft.getMinecraft().getFramebuffer().isStencilEnabled() : "WTW Renderer can't work without stencils. Please enable them";
 
 		GlStateManager.pushMatrix();
@@ -50,7 +74,7 @@ public class WTWRenderer {
 		GL11.glStencilOp(GL11.GL_KEEP, GL11.GL_KEEP, GL11.GL_REPLACE);
 		GL11.glStencilMask(255);
 		GlStateManager.clear(GL11.GL_STENCIL_BUFFER_BIT);
-		borders.run();
+		tear.run();
 		GlStateManager.depthMask(true);
 		GlStateManager.colorMask(true, true, true, true);
 		GL11.glStencilMask(0);

--- a/src/test/java/code/elix_x/excore/test/WTWRendererTest.java
+++ b/src/test/java/code/elix_x/excore/test/WTWRendererTest.java
@@ -22,6 +22,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
@@ -79,21 +80,20 @@ public class WTWRendererTest {
 
 		@Override
 		public void renderTileEntityAt(TileEntity te, double x, double y, double z, float partialTicks, int destroyStage){
-			GlStateManager.pushMatrix();
-			GlStateManager.translate(x, y, z);
-			WTWRenderer.renderNow(() -> {
+			WTWRenderer.render(() -> {
 				
-				renderStencil();
+				renderStencil(x, y, z);
 				
 			}, () -> {
 				
-				render();
+				render(x, y, z);
 				
 			});
-			GlStateManager.popMatrix();
 		}
 		
-		void renderStencil(){
+		void renderStencil(double x, double y, double z){
+			GlStateManager.pushMatrix();
+			GlStateManager.translate(x, y, z);
 			GlStateManager.disableTexture2D();
 			GlStateManager.enableBlend();
 			Tessellator tess = Tessellator.getInstance();
@@ -106,9 +106,12 @@ public class WTWRendererTest {
 			tess.draw();
 			GlStateManager.disableBlend();
 			GlStateManager.enableTexture2D();
+			GlStateManager.popMatrix();
 		}
 		
-		void render(){
+		void render(double x, double y, double z){
+			GlStateManager.pushMatrix();
+			GlStateManager.translate(x, y, z);
 			GlStateManager.pushMatrix();
 			GlStateManager.scale(10, 10, 1);
 			GlStateManager.translate(-0.5, -0.5, 10);
@@ -121,6 +124,7 @@ public class WTWRendererTest {
 			buff.pos(1, 1, 0).tex(1, 0).endVertex();
 			buff.pos(1, 0, 0).tex(1, 1).endVertex();
 			tess.draw();
+			GlStateManager.popMatrix();
 			GlStateManager.popMatrix();
 		}
 

--- a/src/test/java/code/elix_x/excore/test/WTWRendererTest.java
+++ b/src/test/java/code/elix_x/excore/test/WTWRendererTest.java
@@ -98,11 +98,11 @@ public class WTWRendererTest {
 			GlStateManager.enableBlend();
 			Tessellator tess = Tessellator.getInstance();
 			VertexBuffer buff = tess.getBuffer();
-			buff.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_COLOR);
-			buff.pos(0, 0, 0).color(1, 1, 1, 0.5f).endVertex();
-			buff.pos(0, 1, 0).color(1, 1, 1, 0.5f).endVertex();
-			buff.pos(1, 1, 0).color(1, 1, 1, 0.5f).endVertex();
-			buff.pos(1, 0, 0).color(1, 1, 1, 0.5f).endVertex();
+			buff.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION);
+			buff.pos(0, 0, 0).endVertex();
+			buff.pos(0, 1, 0).endVertex();
+			buff.pos(1, 1, 0).endVertex();
+			buff.pos(1, 0, 0).endVertex();
 			tess.draw();
 			GlStateManager.disableBlend();
 			GlStateManager.enableTexture2D();

--- a/src/test/java/code/elix_x/excore/test/WTWRendererTest.java
+++ b/src/test/java/code/elix_x/excore/test/WTWRendererTest.java
@@ -1,0 +1,129 @@
+package code.elix_x.excore.test;
+
+import org.lwjgl.opengl.GL11;
+
+import code.elix_x.excore.utils.client.render.item.ItemStackRenderer;
+import code.elix_x.excore.utils.client.render.wtw.WTWRenderer;
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.EntityRenderer;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.VertexBuffer;
+import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemBlock;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumBlockRenderType;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.World;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.Mod.EventHandler;
+import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+@Mod(modid = WTWRendererTest.MODID)
+public class WTWRendererTest {
+
+	public static final String MODID = "wtwrenderertest";
+
+	@EventHandler
+	public void preInit(FMLPreInitializationEvent event){
+		Block block;
+		GameRegistry.register(block = new Block(Material.ANVIL){
+
+			public boolean hasTileEntity(IBlockState state){
+				return true;
+			}
+
+			@Override
+			public TileEntity createTileEntity(World world, IBlockState state){
+				return new TestTileEntity();
+			}
+
+			public boolean isOpaqueCube(IBlockState state){
+				return false;
+			}
+
+			public EnumBlockRenderType getRenderType(IBlockState state){
+				return EnumBlockRenderType.ENTITYBLOCK_ANIMATED;
+			}
+
+		}.setRegistryName(MODID, "testblock"));
+		GameRegistry.register(new ItemBlock(block).setRegistryName(MODID, "testblock"));
+		GameRegistry.registerTileEntity(TestTileEntity.class, new ResourceLocation(MODID, "testblock").toString());
+	}
+
+	@SideOnly(Side.CLIENT)
+	@EventHandler
+	public void postInit(FMLPostInitializationEvent event){
+		Minecraft.getMinecraft().getFramebuffer().enableStencil();
+		ClientRegistry.bindTileEntitySpecialRenderer(TestTileEntity.class, new TestTileEntityRenderer());
+	}
+
+	public static class TestTileEntity extends TileEntity {
+
+	}
+
+	@SideOnly(Side.CLIENT)
+	public static class TestTileEntityRenderer extends TileEntitySpecialRenderer {
+
+		@Override
+		public void renderTileEntityAt(TileEntity te, double x, double y, double z, float partialTicks, int destroyStage){
+			GlStateManager.pushMatrix();
+			GlStateManager.translate(x, y, z);
+			WTWRenderer.render(() -> {
+				
+				renderStencil();
+				
+			}, () -> {
+				
+				render();
+				
+			});
+			GlStateManager.popMatrix();
+		}
+		
+		void renderStencil(){
+			GlStateManager.disableTexture2D();
+			GlStateManager.enableBlend();
+			Tessellator tess = Tessellator.getInstance();
+			VertexBuffer buff = tess.getBuffer();
+			buff.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_COLOR);
+			buff.pos(0, 0, 0).color(1, 1, 1, 0.5f).endVertex();
+			buff.pos(0, 1, 0).color(1, 1, 1, 0.5f).endVertex();
+			buff.pos(1, 1, 0).color(1, 1, 1, 0.5f).endVertex();
+			buff.pos(1, 0, 0).color(1, 1, 1, 0.5f).endVertex();
+			tess.draw();
+			GlStateManager.disableBlend();
+			GlStateManager.enableTexture2D();
+		}
+		
+		void render(){
+			GlStateManager.pushMatrix();
+			GlStateManager.scale(10, 10, 1);
+			GlStateManager.translate(-0.5, -0.5, 10);
+			Tessellator tess = Tessellator.getInstance();
+			VertexBuffer buff = tess.getBuffer();
+			buff.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX);
+			bindTexture(TextureMap.LOCATION_BLOCKS_TEXTURE);
+			buff.pos(0, 0, 0).tex(0, 1).endVertex();
+			buff.pos(0, 1, 0).tex(0, 0).endVertex();
+			buff.pos(1, 1, 0).tex(1, 0).endVertex();
+			buff.pos(1, 0, 0).tex(1, 1).endVertex();
+			tess.draw();
+			GlStateManager.popMatrix();
+		}
+
+	}
+
+}

--- a/src/test/java/code/elix_x/excore/test/WTWRendererTest.java
+++ b/src/test/java/code/elix_x/excore/test/WTWRendererTest.java
@@ -81,7 +81,7 @@ public class WTWRendererTest {
 		public void renderTileEntityAt(TileEntity te, double x, double y, double z, float partialTicks, int destroyStage){
 			GlStateManager.pushMatrix();
 			GlStateManager.translate(x, y, z);
-			WTWRenderer.render(() -> {
+			WTWRenderer.renderNow(() -> {
 				
 				renderStencil();
 				


### PR DESCRIPTION
Added World Through World renderer.
Allows to render a world through a tear in the current world.
It relies on stencils, which must be activated during initialization by users of WTW renderer.

I am irresponsible for all conflicts caused by incorrect usage of the renderer.